### PR TITLE
Fix/api key naming  consistency

### DIFF
--- a/src/lib/text_to_speech.py
+++ b/src/lib/text_to_speech.py
@@ -32,7 +32,7 @@ AVAILABLE_VOICES = {
     'shimmer': 'Shimmer - Clear and dynamic female voice, excellent for presentations'
 }
 
-def split_text(text, max_length=500):
+def split_text(text, max_length=4000):
     """Split text into chunks for text-to-speech conversion."""
     print(f"Text length = {len(text)}")
     chunks = []

--- a/src/lib/translations.py
+++ b/src/lib/translations.py
@@ -2,7 +2,7 @@ from openai import OpenAI
 import os
 from dataclasses import dataclass
 
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY_HEY_BRO"))
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 @dataclass
 class TranslationResult:


### PR DESCRIPTION
This PR fixes:
- The inconsistent API Key naming
- Adjusts the TTS chunk size to 4k chars to avoid too many chunks and calls to the Open AI API